### PR TITLE
Update README title

### DIFF
--- a/powershell/vsphere/README.md
+++ b/powershell/vsphere/README.md
@@ -1,4 +1,4 @@
-# List EC2 instances using the AWS SDK for Python
+# List vSphere machines using PowerCLI
 
 Sample showing how you can integrate vRO with vSphere using PowerCLI
 


### PR DESCRIPTION
In the readme vro-polyglot-scripts/powershell/vsphere/readme.md, the title doesn't match the subject ( I think, it's a copy/paste error): 
List EC2 instances using the AWS SDK for Python --> List vSphere machines using PowerCLI